### PR TITLE
Fixing the database with the correct name (corresponding to .env file)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     environment:
       - NODE_ENV=development
       - DB_HOST=postgres
-    command: sh -c "sleep 5 && DATABASE_URL='postgres://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:${DB_PORT:-5432}/${DB_NAME:-topsveltekit}' bunx node-pg-migrate up"
+    command: sh -c "sleep 5 && DATABASE_URL='postgres://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:${DB_PORT:-5432}/${DB_NAME:-faivor}' bunx node-pg-migrate up"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
During initialisation / migration, the database name should correspond to the name used in the .env file